### PR TITLE
chore: remove setup-node action from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
       - uses: joshjohanning/publish-github-action@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by removing the Node.js setup step from the `publish.yml` workflow. This simplifies the workflow and removes an unnecessary dependency.