### PR TITLE
test: add unit test for ruleset update when source config contains API-only fields

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1542,6 +1542,7 @@ describe('Bulk GitHub Repository Settings Action', () => {
       expect(result.ruleset).toBe('unchanged');
       expect(result.rulesetId).toBe(456);
       expect(result.message).toContain('already up to date');
+      expect(mockOctokit.rest.repos.getRepoRuleset).toHaveBeenCalled();
       expect(mockOctokit.rest.repos.updateRepoRuleset).not.toHaveBeenCalled();
       expect(mockOctokit.rest.repos.createRepoRuleset).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Testing improvements:

* Added a test to verify that `syncRepositoryRuleset` does not trigger an update if the provided ruleset config includes API-only fields and is otherwise unchanged, ensuring robustness when using raw API exports as input.