### PR TITLE
docs: update PR title for syncing workflow configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Sync one or more workflow files to `.github/workflows/` in target repositories v
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
     workflow-files: './config/workflows/ci.yml,./config/workflows/release.yml'
-    workflow-files-pr-title: 'chore: update workflow files'
+    workflow-files-pr-title: 'chore: sync workflow configuration'
 ```
 
 Or with repo-specific overrides in `repos.yml`:


### PR DESCRIPTION
- Updated the example in `README.md` to use `chore: sync workflow configuration` as the default pull request title for workflow file updates.