### PR TITLE
feat!: upgrade GitHub Actions runtime from node20 to node24

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,8 @@ const { functionToTest } = await import('../src/index.js');
 
 ### Node Runtime
 
-- Use the same Node.js runtime version configured in this repo's `action.yml` (currently `node24`) for `runs.using`
+- Only use Node.js runtimes officially supported by GitHub Actions (see [GitHub Actions documentation](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions) for current supported versions)
+- Use the same Node.js runtime version configured in this repo's `action.yml` for `runs.using`
 - When updating Node.js support, update `runs.using` in `action.yml`, the `engines.node` range in `package.json`, and CI/test matrices together to stay consistent
 
 ### Input Handling

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@ const { functionToTest } = await import('../src/index.js');
 
 ### Node Runtime
 
-- Use the same Node.js runtime version configured in this repo's `action.yml` (currently `node20`) for `runs.using`
+- Use the same Node.js runtime version configured in this repo's `action.yml` (currently `node24`) for `runs.using`
 - When updating Node.js support, update `runs.using` in `action.yml`, the `engines.node` range in `package.json`, and CI/test matrices together to stay consistent
 
 ### Input Handling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
           fi
 
       - name: Check npm version compatibility
-        uses: joshjohanning/npm-version-check-action@v1
+        uses: joshjohanning/npm-version-check-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: joshjohanning/publish-github-action@v2
+      - uses: joshjohanning/publish-github-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_package_command: npm run package

--- a/README.md
+++ b/README.md
@@ -863,7 +863,7 @@ For better security and rate limits, use a GitHub App:
 ```yml
 - name: Generate GitHub App Token
   id: app-token
-  uses: actions/create-github-app-token@v2
+  uses: actions/create-github-app-token@v3
   with:
     app-id: ${{ secrets.APP_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -917,7 +917,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Update repository settings in bulk across multiple GitHub repositories.
 > [!TIP]
 > **Looking for a working example?** See the [Working Example](#working-example) section for a complete workflow with GitHub App authentication and a real `repos.yml` configuration file.
 
+## What's new
+
+Please refer to the [release page](https://github.com/joshjohanning/bulk-github-repo-settings-sync-action/releases) for the latest release notes.
+
 ## Features
 
 - 🔧 Update pull request merge strategies (squash, merge, rebase)
@@ -46,7 +50,7 @@ Update repository settings in bulk across multiple GitHub repositories.
 
 ```yml
 - name: Update Repository Settings
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories: 'owner/repo1,owner/repo2,owner/repo3'
@@ -110,7 +114,7 @@ Use in workflow:
 
 ```yml
 - name: Update Repository Settings
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -189,7 +193,7 @@ Use in workflow:
 
 ```yml
 - name: Apply Rules-Based Settings
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'settings-config.yml'
@@ -235,7 +239,7 @@ Sync a `dependabot.yml` file to `.github/dependabot.yml` in target repositories 
 
 ```yml
 - name: Sync Dependabot Config
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -269,7 +273,7 @@ Sync repository rulesets across multiple repositories:
 
 ```yml
 - name: Sync Repository Rulesets
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -345,7 +349,7 @@ By default, syncing rulesets will create or update the specified ruleset by name
 
 ```yml
 - name: Sync Repository Rulesets (delete unmanaged)
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -368,7 +372,7 @@ Sync a pull request template file to `.github/pull_request_template.md` in targe
 
 ```yml
 - name: Sync Pull Request Template
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -404,7 +408,7 @@ Sync one or more workflow files to `.github/workflows/` in target repositories v
 
 ```yml
 - name: Sync Workflow Files
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -444,7 +448,7 @@ Sync autolink references across multiple repositories to automatically link keyw
 
 ```yml
 - name: Sync Autolinks
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -504,7 +508,7 @@ Sync a `copilot-instructions.md` file to `.github/copilot-instructions.md` in ta
 
 ```yml
 - name: Sync Copilot Instructions
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -540,7 +544,7 @@ Sync a `CODEOWNERS` file to target repositories via pull requests. CODEOWNERS fi
 
 ```yml
 - name: Sync CODEOWNERS
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -640,7 +644,7 @@ Sync a `.gitignore` file to `.gitignore` in target repositories via pull request
 
 ```yml
 - name: Sync .gitignore Config
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -694,7 +698,7 @@ Sync npm `scripts` and/or `engines` from a source `package.json` to target repos
 
 ```yml
 - name: Sync package.json Properties
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories-file: 'repos.yml'
@@ -750,7 +754,7 @@ Only the fields you enable for syncing (`package-json-sync-scripts`, `package-js
 
 ```yml
 - name: Update All Org Repositories
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories: 'all'
@@ -765,7 +769,7 @@ Preview changes without applying them:
 
 ```yml
 - name: Preview Changes
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     repositories: 'owner/repo1,owner/repo2'
@@ -866,7 +870,7 @@ For better security and rate limits, use a GitHub App:
     owner: ${{ github.repository_owner }}
 
 - name: Update Repository Settings
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ steps.app-token.outputs.token }}
     # ... other inputs
@@ -878,7 +882,7 @@ Alternatively, use a PAT with `repo` scope:
 
 ```yml
 - name: Update Repository Settings
-  uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+  uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
   with:
     github-token: ${{ secrets.PAT_TOKEN }}
     # ... other inputs
@@ -921,7 +925,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Update Repository Settings
-        uses: joshjohanning/bulk-github-repo-settings-sync-action@v1
+        uses: joshjohanning/bulk-github-repo-settings-sync-action@v2
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           repositories-file: 'repos.yml'

--- a/action.yml
+++ b/action.yml
@@ -173,5 +173,5 @@ outputs:
     description: 'JSON array of update results for each repository'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bulk-github-repo-settings-sync-action",
-  "version": "1.15.4",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bulk-github-repo-settings-sync-action",
-      "version": "1.15.4",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",
@@ -28,7 +28,7 @@
         "prettier": "^3.8.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bulk-github-repo-settings-sync-action",
   "description": "Update repository settings in bulk for multiple GitHub repositories",
-  "version": "1.15.4",
+  "version": "2.0.0",
   "type": "module",
   "author": {
     "name": "Josh Johanning",
@@ -29,7 +29,7 @@
     ".": "./dist/index.js"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "scripts": {
     "bundle": "npm run format:write && npm run package",


### PR DESCRIPTION
## Summary

Upgrade the GitHub Actions runtime from `node20` to `node24` since `node20` is now deprecated.

## Changes

- **action.yml**: Updated `runs.using` from `node20` to `node24`
- **package.json**: Bumped version from `1.15.4` to `2.0.0`, updated `engines.node` from `>=20` to `>=24`
- **.github/workflows/ci.yml**: Updated `node-version` from `20` to `24`
- **.github/copilot-instructions.md**: Updated node runtime reference from `node20` to `node24`
- **README.md**: Updated all usage examples from `@v1` to `@v2`, added "What's new" section
- **package-lock.json**: Synced with updated package.json

## ⚠️ Breaking Changes

- **Runtime**: GitHub Actions runtime changed from `node20` to `node24`
- **Major version bump**: `v1` → `v2` — users must update their workflow references from `@v1` to `@v2`