### PR TITLE
fix: exclude organization rulesets from delete-unmanaged

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -5031,7 +5031,8 @@ describe('Bulk GitHub Repository Settings Action', () => {
       expect(mockOctokit.paginate).toHaveBeenCalledWith(mockOctokit.rest.repos.getRepoRulesets, {
         owner: 'owner',
         repo: 'repo',
-        per_page: 100
+        per_page: 100,
+        includes_parents: false
       });
       expect(mockOctokit.rest.repos.createRepoRuleset).toHaveBeenCalledWith({
         owner: 'owner',
@@ -5342,8 +5343,45 @@ describe('Bulk GitHub Repository Settings Action', () => {
       expect(mockOctokit.paginate).toHaveBeenCalledWith(mockOctokit.rest.repos.getRepoRulesets, {
         owner: 'owner',
         repo: 'repo',
-        per_page: 100
+        per_page: 100,
+        includes_parents: false
       });
+    });
+
+    test('should exclude organization rulesets from delete-unmanaged', async () => {
+      const rulesetConfig = {
+        name: 'repo-ruleset',
+        target: 'branch',
+        enforcement: 'active',
+        rules: [{ type: 'deletion' }]
+      };
+
+      setMockFileContent(JSON.stringify(rulesetConfig));
+      // includes_parents=false means org rulesets won't appear here,
+      // so only repo-level rulesets are returned
+      mockOctokit.paginate.mockResolvedValue([
+        { id: 1, name: 'repo-ruleset' },
+        { id: 2, name: 'unmanaged-repo-ruleset' }
+      ]);
+      mockOctokit.rest.repos.getRepoRuleset.mockResolvedValue({
+        data: rulesetConfig
+      });
+
+      const result = await syncRepositoryRuleset(mockOctokit, 'owner/repo', './ruleset.json', true, false);
+
+      expect(result.success).toBe(true);
+      // Should only delete the unmanaged repo ruleset, not any org rulesets
+      expect(mockOctokit.rest.repos.deleteRepoRuleset).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.rest.repos.deleteRepoRuleset).toHaveBeenCalledWith({
+        owner: 'owner',
+        repo: 'repo',
+        ruleset_id: 2
+      });
+      // Verify includes_parents=false was passed
+      expect(mockOctokit.paginate).toHaveBeenCalledWith(
+        mockOctokit.rest.repos.getRepoRulesets,
+        expect.objectContaining({ includes_parents: false })
+      );
     });
 
     test('should delete unmanaged rulesets when updating a ruleset', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bulk-github-repo-settings-sync-action",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bulk-github-repo-settings-sync-action",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bulk-github-repo-settings-sync-action",
   "description": "Update repository settings in bulk for multiple GitHub repositories",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "type": "module",
   "author": {
     "name": "Josh Johanning",

--- a/src/index.js
+++ b/src/index.js
@@ -2640,12 +2640,14 @@ export async function syncRepositoryRulesets(octokit, repo, rulesetFilePaths, de
   const managedNames = new Set(rulesetConfigs.map(r => r.name));
 
   // Get existing rulesets for the repository (once for all files)
+  // Use includes_parents=false to exclude organization-level rulesets
   let existingRulesets = [];
   try {
     existingRulesets = await octokit.paginate(octokit.rest.repos.getRepoRulesets, {
       owner,
       repo: repoName,
-      per_page: 100
+      per_page: 100,
+      includes_parents: false
     });
   } catch (error) {
     if (error.status === 404) {


### PR DESCRIPTION
When `delete-unmanaged-rulesets: true` was enabled, organization-level inherited rulesets were included in the fetch and flagged for deletion. Since org rulesets can't be deleted at the repo level, this caused confusing dry-run output and potential API errors.

Fix: pass `includes_parents: false` to `getRepoRulesets` so only repo-level rulesets are fetched, compared, and potentially deleted.

Closes #142