### PR TITLE
chore: remove unused @actions/github dependency

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -28,13 +28,6 @@ const mockCore = {
   }
 };
 
-// Mock the @actions/github module
-const mockGithub = {
-  context: {
-    repo: { owner: 'test-owner', repo: 'test-repo' }
-  }
-};
-
 // Mock octokit instance
 const mockOctokit = {
   rest: {
@@ -274,7 +267,6 @@ function setMockYamlContent(result, forContent = '__default__') {
 
 // Mock the modules before importing the main module
 jest.unstable_mockModule('@actions/core', () => mockCore);
-jest.unstable_mockModule('@actions/github', () => mockGithub);
 jest.unstable_mockModule('@octokit/rest', () => ({
   Octokit: jest.fn(() => mockOctokit)
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",
-        "@actions/github": "^9.1.0",
         "@octokit/rest": "^22.0.1",
         "js-yaml": "^4.1.1"
       },
@@ -58,31 +57,6 @@
       "license": "MIT",
       "dependencies": {
         "@actions/io": "^3.0.2"
-      }
-    },
-    "node_modules/@actions/github": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.0.tgz",
-      "integrity": "sha512-u0hDGQeCS+7VNoLA8hYG65RLdPLMaPGfka0sZ0up7P0AiShqfX6xcuXNteGkQ7X7Tod7AMNwHd4p7DS63i8zzA==",
-      "license": "MIT",
-      "dependencies": {
-        "@actions/http-client": "^3.0.2",
-        "@octokit/core": "^7.0.6",
-        "@octokit/plugin-paginate-rest": "^14.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
-        "@octokit/request": "^10.0.7",
-        "@octokit/request-error": "^7.1.0",
-        "undici": "^6.23.0"
-      }
-    },
-    "node_modules/@actions/http-client": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
-      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "^0.0.6",
-        "undici": "^6.23.0"
       }
     },
     "node_modules/@actions/io": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^3.0.0",
-    "@actions/github": "^9.1.0",
     "@octokit/rest": "^22.0.1",
     "js-yaml": "^4.1.1"
   },


### PR DESCRIPTION
This dependency was used in the initial commit for `github.context` but was removed from source in PR #1. The test mock and package dependency were never cleaned up.

No source code uses `@actions/github` — the action creates its own Octokit via `@octokit/rest`.