### PR TITLE
docs: update GitHub App docs to use client-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,14 +920,14 @@ For better security and rate limits, use a GitHub App:
    - **Pull Requests**: Read and write (required if syncing `dependabot.yml`)
    - **Organization Custom Properties**: Read (required when using organization custom property filtering, including `custom-property` selectors in `settings-config.yml` or the `custom-property-name` / `custom-property-value` action inputs)
 2. Install it to your organization/repositories
-3. Add `APP_ID` and `APP_PRIVATE_KEY` as repository secrets
+3. Add `CLIENT_ID` and `APP_PRIVATE_KEY` as repository secrets
 
 ```yml
 - name: Generate GitHub App Token
   id: app-token
   uses: actions/create-github-app-token@v3
   with:
-    app-id: ${{ secrets.APP_ID }}
+    client-id: ${{ secrets.CLIENT_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
     owner: ${{ github.repository_owner }}
 
@@ -982,7 +982,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/README.md
+++ b/README.md
@@ -920,14 +920,14 @@ For better security and rate limits, use a GitHub App:
    - **Pull Requests**: Read and write (required if syncing `dependabot.yml`)
    - **Organization Custom Properties**: Read (required when using organization custom property filtering, including `custom-property` selectors in `settings-config.yml` or the `custom-property-name` / `custom-property-value` action inputs)
 2. Install it to your organization/repositories
-3. Add `CLIENT_ID` and `APP_PRIVATE_KEY` as repository secrets
+3. Add `APP_CLIENT_ID` as a repository variable and `APP_PRIVATE_KEY` as a repository secret
 
 ```yml
 - name: Generate GitHub App Token
   id: app-token
   uses: actions/create-github-app-token@v3
   with:
-    client-id: ${{ secrets.CLIENT_ID }}
+    client-id: ${{ vars.APP_CLIENT_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
     owner: ${{ github.repository_owner }}
 
@@ -982,7 +982,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.CLIENT_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
Update the README examples for actions/create-github-app-token@v3 to use client-id.

Prevents this warning:
Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.

See https://github.com/actions/create-github-app-token/pull/353