### PR TITLE
docs: clarify ruleset pass-through and supported target types

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ repos:
 - Updates the ruleset if a ruleset with the same name already exists
 - Rulesets are identified by the `name` field in each JSON configuration
 - Each JSON file should contain a valid ruleset configuration matching the [GitHub Rulesets API schema](https://docs.github.com/en/rest/repos/rules)
+- Ruleset JSON is passed through to the GitHub API as-is (read-only fields like `id`, `source`, `source_type`, `created_at`, `updated_at`, `_links`, and `current_user_can_bypass` are stripped automatically), so any rule type or parameter supported by the API will sync — no action update required when GitHub adds new ones
+- All `target` values supported by the API work: `branch` (default), `tag`, and `push`. It's recommended to set `target` explicitly in each ruleset JSON file to avoid ambiguity
 
 **Example Ruleset JSON (`ci-ruleset.json`):**
 


### PR DESCRIPTION
Clarifies two things about ruleset syncing that weren't obvious from the existing docs:

- The action passes ruleset JSON through to the GitHub Rulesets API as-is (with read-only fields like `id`, `source`, `source_type`, `created_at`, etc. stripped automatically). That means new rule types and parameters GitHub adds, such as `copilot_code_review.parameters.review_draft_pull_requests`, sync without needing an action update.
- All `target` values the API supports work, not just `branch`. Calls out `branch` (default), `tag`, and `push`, and recommends setting `target` explicitly in each ruleset JSON file.

README-only change; existing examples already include `"target": "branch"` so no example edits were needed.