### PR TITLE
fix: upgrade js-yaml to 5.2.2 (CVE-2026-73643)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "^3.0.1",
         "@octokit/rest": "^22.0.1",
-        "js-yaml": "^5.2.1"
+        "js-yaml": "^5.2.2"
       },
       "devDependencies": {
         "@joshjohanning/make-coverage-badge-better": "^1.0.1",
@@ -5965,9 +5965,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@actions/core": "^3.0.1",
     "@octokit/rest": "^22.0.1",
-    "js-yaml": "^5.2.1"
+    "js-yaml": "^5.2.2"
   },
   "devDependencies": {
     "@joshjohanning/make-coverage-badge-better": "^1.0.1",


### PR DESCRIPTION
## Summary
Upgrade js-yaml from 5.2.1 to 5.2.2 to fix CVE-2026-73643.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-73643 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-73643` |
| **File** | `package-lock.json` (dependency: `js-yaml`) |
| **Assessment** | Likely exploitable |

**Description**: js-yaml: js-yaml: Denial of Service via exponential parsing in flow collections

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-73643` flagged this pattern.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
